### PR TITLE
created custom modal for datasets that will not be shared

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -25,7 +25,9 @@ import {connect} from 'react-redux';
 import {loadSampleConfigurations} from './actions';
 import {replaceLoadDataModal} from './factories/load-data-modal';
 import CustomPanelHeader from './components/custom-panel-header';
+import {CustomDataTableModal} from './factories/custom-data-table-modal';
 import {PanelHeaderFactory} from 'kepler.gl/components';
+import {DataTableModalFactory} from 'kepler.gl/components';
 import KeplerGlSchema from 'kepler.gl/schemas';
 import Button from './button';
 import downloadJsonFile from "./file-download";
@@ -38,8 +40,11 @@ const shareable = config.can_share;
 let KeplerGl;
 if (!shareable) {
   const CustomPanelHeaderFactory = () => CustomPanelHeader;
+  const CustomDataTableModalFactory = () => CustomDataTableModal;
+
   KeplerGl = require('kepler.gl/components').injectComponents([
     [PanelHeaderFactory, CustomPanelHeaderFactory],
+    [DataTableModalFactory, CustomDataTableModalFactory],
     replaceLoadDataModal()
   ]);
 } else {

--- a/client/src/factories/custom-data-table-modal.js
+++ b/client/src/factories/custom-data-table-modal.js
@@ -1,0 +1,28 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+import React, {Component} from 'react';
+
+let customDataTableStyle = {
+  fontSize: '24px',
+  padding: '20px',
+  textAlign: 'center'
+};
+
+export const CustomDataTableModal = () => (<div style={customDataTableStyle}>This data cannot be viewed in a table</div>);


### PR DESCRIPTION
Fixes #28 

This is a solution that changes the content of the data table modal to display a message rather than the data. It does not affect the "show data table" button. Currently, this view is determined by config.can_share, because if we don't want the data to be accessible there for download, it should also not be viewed in the table view. 

![image](https://user-images.githubusercontent.com/17235236/47462822-80366880-d7b2-11e8-90d9-28a28d602168.png)

@mikefab please review.
